### PR TITLE
Add search_path to SQL index script

### DIFF
--- a/sql_postgis/gracethd_50_index.sql
+++ b/sql_postgis/gracethd_50_index.sql
@@ -1,6 +1,7 @@
 /*GraceTHD v2-RC2*/
 /* Creation des index*/
 /*PostGIS*/
+SET search_path TO gracethd, public;
 
 DROP INDEX IF EXISTS ad_ban_id_idx; CREATE INDEX  ad_ban_id_idx ON t_adresse(ad_ban_id);
 


### PR DESCRIPTION
All previous scripts use a search_path parameter to set tup the default
schema to gracethd except this one.
